### PR TITLE
use subprocess.run instead of deprecated os.system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VSCode
+.vscode/

--- a/KeePassDiff/launch.py
+++ b/KeePassDiff/launch.py
@@ -1,14 +1,11 @@
 import os
 import subprocess
-from shlex import quote
 
 
 def launch():
     path = os.path.dirname(os.path.abspath(__file__))
-    app_path = f"{path}/app.py"
-
-    app_path = quote(app_path)
-    subprocess.run(args=["streamlit", "run", app_path], shell=True)
+    app_path = os.path.join(path, "app.py")
+    subprocess.run(["streamlit", "run", app_path], shell=True)
 
 
 if __name__ == "__main__":

--- a/KeePassDiff/launch.py
+++ b/KeePassDiff/launch.py
@@ -1,10 +1,11 @@
 import os
+import subprocess
 
 
 def launch():
     path = os.path.dirname(os.path.abspath(__file__))
 
-    os.system(f"streamlit run {path}/app.py")
+    subprocess.run(f"streamlit run {path}/app.py", shell=True)
 
 
 if __name__ == "__main__":

--- a/KeePassDiff/launch.py
+++ b/KeePassDiff/launch.py
@@ -1,11 +1,14 @@
 import os
 import subprocess
+from shlex import quote
 
 
 def launch():
     path = os.path.dirname(os.path.abspath(__file__))
+    app_path = f"{path}/app.py"
 
-    subprocess.run(f"streamlit run {path}/app.py", shell=True)
+    app_path = quote(app_path)
+    subprocess.run(args=["streamlit", "run", app_path], shell=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When I run `kpd` installed with `pipx`, it fails with `sh: streamlit: command not found` since the interpreter from the shebang is not used for the os.system call. This PR aims to fix that by using subprocess with `shell=True`, which propagates the necessary environment variables.


## Summary by Sourcery

Enhancements:
- Replace deprecated os.system call with subprocess.run for launching the Streamlit app