### PR TITLE
Add pipx support by running streamlit with streamlit.web.cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VSCode
+.vscode/

--- a/KeePassDiff/launch.py
+++ b/KeePassDiff/launch.py
@@ -5,9 +5,8 @@ from streamlit.web import cli
 
 def launch():
     path = os.path.dirname(os.path.abspath(__file__))
-    app_path = f"{path}/app.py"
 
-    sys.argv = ["streamlit", "run", f"{app_path}"]
+    sys.argv = ["streamlit", "run", f"{os.path.join(path, "app.py")}"]
     sys.exit(cli.main())
 
 

--- a/KeePassDiff/launch.py
+++ b/KeePassDiff/launch.py
@@ -1,14 +1,11 @@
 import os
 import subprocess
-from shlex import quote
 
 
 def launch():
     path = os.path.dirname(os.path.abspath(__file__))
-    app_path = f"{path}/app.py"
-
-    app_path = quote(app_path)
-    subprocess.run(args=["streamlit", "run", app_path], shell=True)
+    app_path = os.path.join(path, "app.py")
+    subprocess.run(["streamlit", "run", app_path], shell=True)
 
 
 if __name__ == "__main__":

--- a/KeePassDiff/launch.py
+++ b/KeePassDiff/launch.py
@@ -1,10 +1,11 @@
 import os
+import subprocess
 
 
 def launch():
     path = os.path.dirname(os.path.abspath(__file__))
 
-    os.system(f"streamlit run {path}/app.py")
+    subprocess.run(f"streamlit run {path}/app.py", shell=True)
 
 
 if __name__ == "__main__":

--- a/KeePassDiff/launch.py
+++ b/KeePassDiff/launch.py
@@ -1,11 +1,14 @@
 import os
 import subprocess
+from shlex import quote
 
 
 def launch():
     path = os.path.dirname(os.path.abspath(__file__))
+    app_path = f"{path}/app.py"
 
-    subprocess.run(f"streamlit run {path}/app.py", shell=True)
+    app_path = quote(app_path)
+    subprocess.run(args=["streamlit", "run", app_path], shell=True)
 
 
 if __name__ == "__main__":

--- a/KeePassDiff/launch.py
+++ b/KeePassDiff/launch.py
@@ -1,11 +1,14 @@
 import os
-import subprocess
+import sys
+from streamlit.web import cli
 
 
 def launch():
     path = os.path.dirname(os.path.abspath(__file__))
-    app_path = os.path.join(path, "app.py")
-    subprocess.run(["streamlit", "run", app_path], shell=True)
+    app_path = f"{path}/app.py"
+
+    sys.argv = ["streamlit", "run", f"{app_path}"]
+    sys.exit(cli.main())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The original intent of #8 was to fix `pipx` installations by using subprocess.run instead of os.system. However, that didn't work, since the shell used to run the command wasn't sourcing the venv. Instead, this PR aims to use streamlit.web.cli to [run streamlit from within the script](https://stackoverflow.com/questions/62760929/how-can-i-run-a-streamlit-app-from-within-a-python-script), which should hopefully also help to solve cross-platform compatability issues. Any thoughts welcome!

To prevent future breaking changes, it might also be necessary to freeze the version of streamlit in place.

## Summary by Sourcery

Invoke Streamlit directly via its internal CLI entry point instead of spawning a shell process to ensure proper virtual environment activation and enable pipx compatibility.

New Features:
- Support launching the Streamlit app under pipx by running it programmatically through Streamlit’s internal CLI

Enhancements:
- Replace the os.system call with a direct invocation of streamlit.web.cli.main using sys.argv
- Export the CLI exit code via sys.exit for correct process termination
- Introduce an explicit app_path variable for cleaner path handling